### PR TITLE
refactor: added HTTPURLResponse to returned result tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ let result = await pexels.getCuratedPhotos()
 switch result {
 case .failure(let error):
     print(error.description)
-case .success(let (photos, pageInfo)):
+case .success(let (data, paging, response)):
     // access photos
+    // data -> [PSPhoto]
+    // paging -> PSPagingInfo
+    // response -> HTTPURLResponse
 }
 
 // fetch images metadata using completion handlers
@@ -59,8 +62,11 @@ pexels.getCuratedPhotos() { result in
     switch result {
     case .failure(let error):
         print(error.description)
-    case .success(let (photos, pageInfo)):
+    case .success(let (data, paging, response)):
         // access photos
+        // data -> [PSPhoto]
+        // paging -> PSPagingInfo
+        // response -> HTTPURLResponse
     }
 }
 ```

--- a/Sources/PexelsSwift/Documentation.docc/Documentation.md
+++ b/Sources/PexelsSwift/Documentation.docc/Documentation.md
@@ -35,8 +35,11 @@ let result = await pexels.getCuratedPhotos()
 switch result {
 case .failure(let error):
     print(error.description)
-case .success(let (photos, pageInfo)):
+case .success(let (data, paging, response)):
     // access photos
+    // data -> [PSPhoto]
+    // paging -> PSPagingInfo
+    // response -> HTTPURLResponse
 }
 
 // fetch images metadata using completion handlers
@@ -44,8 +47,11 @@ pexels.getCuratedPhotos() { result in
     switch result {
     case .failure(let error):
         print(error.description)
-    case .success(let (photos, pageInfo)):
+    case .success(let (data, paging, response)):
         // access photos
+        // data -> [PSPhoto]
+        // paging -> PSPagingInfo
+        // response -> HTTPURLResponse
     }
 }
 ```

--- a/Sources/PexelsSwift/Documentation.docc/Getting-Started.md
+++ b/Sources/PexelsSwift/Documentation.docc/Getting-Started.md
@@ -51,15 +51,16 @@ case .failure(let error):
     print(error.description)
     // handle the error
 // access the result's content
-case .success(let (photos, pageInfo)):
+case .success(let (data, paging, response)):
     ...
 }
 ```
 
 In the code above you can see we get `photos` and `metadata` from our result in the `.success` case.
 
-- **photos** is an array of ``PSPhoto``.
-- **pageInfo** is a struct ``PSPagingInfo`` which contains some information for paging like the current page, results per page, the URL to the next/previous page and the number of total results.
+- **data** is an array of ``PSPhoto``.
+- **paging** is a struct ``PSPagingInfo`` which contains some information for paging like the current page, results per page, the URL to the next/previous page and the number of total results.
+- **response** is of type [`HTTPURLResponse`](https://developer.apple.com/documentation/foundation/httpurlresponse)
 
 ### Get the Image URL
 
@@ -68,8 +69,8 @@ Now we want to get the URLs for the thumbnails of the fetched images.
 ```swift
 switch result {
 ...
-case .success(let (photos, pageInfo)):
-    let urls = photos.compactMap { 
+case .success(let (data, paging, response)):
+    let urls = data.compactMap { 
         URL(string: $0.source[PSPhoto.Size.tiny.rawValue]) 
     }
     // now you can load the image from each URL and 

--- a/Sources/PexelsSwift/PexelsSwift+Collections.swift
+++ b/Sources/PexelsSwift/PexelsSwift+Collections.swift
@@ -32,10 +32,10 @@ public extension PexelsSwift {
         guard let url = components.url else { return .failure(.badURL) }
         guard !apiKey.isEmpty else { return .failure(.noAPIKey) }
 
-        let result: Result<CollectionResults, PSError> = await fetch(url: url)
+        let result: PSResult<CollectionResults> = await fetch(url: url)
         switch result {
         case .failure(let error): return .failure(error)
-        case .success(let wrapper):
+        case .success(let (wrapper, response)):
             let metaData = PSPagingInfo(
                 page: wrapper.page,
                 perPage: wrapper.perPage,
@@ -43,7 +43,7 @@ public extension PexelsSwift {
                 previousPage: wrapper.previousPage,
                 nextPage: wrapper.nextPage
             )
-            return .success((wrapper.collections, metaData))
+            return .success((wrapper.collections, metaData, response))
         }
     }
 

--- a/Sources/PexelsSwift/PexelsSwift+Photos.swift
+++ b/Sources/PexelsSwift/PexelsSwift+Photos.swift
@@ -24,7 +24,7 @@ public extension PexelsSwift {
         guard let url = URL(string: API.photoByID(id))
         else { return .failure(.badURL) }
 
-        let result: Result<PSPhoto, PSError> = await fetch(url: url)
+        let result: PSResult<PSPhoto> = await fetch(url: url)
         switch result {
         case .failure(let error): return .failure(error)
         case .success(let photo): return .success(photo)

--- a/Sources/PexelsSwift/PexelsSwift+Videos.swift
+++ b/Sources/PexelsSwift/PexelsSwift+Videos.swift
@@ -23,10 +23,10 @@ public extension PexelsSwift {
         guard !apiKey.isEmpty else { return .failure(.noAPIKey) }
         guard let url = URL(string: API.videoByID(id))
         else { return .failure(.badURL) }
-        let result: Result<PSVideo, PSError> = await fetch(url: url)
+        let result: PSResult<PSVideo> = await fetch(url: url)
         switch result {
         case .failure(let error): return .failure(error)
-        case .success(let video): return .success(video)
+        case .success(let response): return .success(response)
         }
     }
 

--- a/Tests/PexelsSwiftTests/PexelsSwiftTests.swift
+++ b/Tests/PexelsSwiftTests/PexelsSwiftTests.swift
@@ -11,7 +11,7 @@ import XCTest
 // swiftlint:disable:next type_body_length
 final class PexelsSwiftTests: XCTestCase {
 
-//    let apiKey = ProcessInfo.processInfo.environment["PEXELS_API_KEY"] ?? ""
+    let apiKey = ProcessInfo.processInfo.environment["PEXELS_API_KEY"] ?? ""
 
     let timeOut: TimeInterval = 20
     let logLevel: PSLogLevel = .debug

--- a/Tests/PexelsSwiftTests/PexelsSwiftTests.swift
+++ b/Tests/PexelsSwiftTests/PexelsSwiftTests.swift
@@ -11,7 +11,7 @@ import XCTest
 // swiftlint:disable:next type_body_length
 final class PexelsSwiftTests: XCTestCase {
 
-    let apiKey = ProcessInfo.processInfo.environment["PEXELS_API_KEY"] ?? ""
+//    let apiKey = ProcessInfo.processInfo.environment["PEXELS_API_KEY"] ?? ""
 
     let timeOut: TimeInterval = 20
     let logLevel: PSLogLevel = .debug
@@ -37,8 +37,9 @@ final class PexelsSwiftTests: XCTestCase {
         switch result {
         case .failure(let error):
             XCTFail(error.description)
-        case .success(let photo):
-            XCTAssertEqual(photo.id, 2014422)
+        case .success(let (data, response)):
+            XCTAssertEqual(data.id, 2014422)
+            XCTAssertEqual(response.statusCode, 200)
         }
     }
 
@@ -50,8 +51,9 @@ final class PexelsSwiftTests: XCTestCase {
         switch result {
         case .failure(let error):
             XCTFail(error.description)
-        case .success(let (photos, _)):
-            XCTAssertFalse(photos.isEmpty)
+        case .success(let (data, _, response)):
+            XCTAssertFalse(data.isEmpty)
+            XCTAssertEqual(response.statusCode, 200)
         }
     }
 
@@ -68,8 +70,9 @@ final class PexelsSwiftTests: XCTestCase {
         switch result {
         case .failure(let error):
             XCTFail(error.description)
-        case .success(let (photos, _)):
-            XCTAssertFalse(photos.isEmpty)
+        case .success(let (data, _, response)):
+            XCTAssertFalse(data.isEmpty)
+            XCTAssertEqual(response.statusCode, 200)
         }
     }
 
@@ -81,8 +84,9 @@ final class PexelsSwiftTests: XCTestCase {
         switch result {
         case .failure(let error):
             XCTFail(error.description)
-        case .success(let (photos, _)):
-            XCTAssertFalse(photos.isEmpty)
+        case .success(let (data, _, response)):
+            XCTAssertFalse(data.isEmpty)
+            XCTAssertEqual(response.statusCode, 200)
         }
     }
 
@@ -94,8 +98,9 @@ final class PexelsSwiftTests: XCTestCase {
         switch result {
         case .failure(let error):
             XCTFail(error.description)
-        case .success(let (categories, _)):
-            XCTAssertFalse(categories.isEmpty)
+        case .success(let (data, _, response)):
+            XCTAssertFalse(data.isEmpty)
+            XCTAssertEqual(response.statusCode, 200)
         }
 
     }
@@ -121,8 +126,9 @@ final class PexelsSwiftTests: XCTestCase {
         switch result {
         case .failure(let error):
             XCTFail(error.description)
-        case .success(let video):
-            XCTAssertEqual(video.id, 6466763)
+        case .success(let (data, response)):
+            XCTAssertEqual(data.id, 6466763)
+            XCTAssertEqual(response.statusCode, 200)
         }
     }
 
@@ -138,8 +144,9 @@ final class PexelsSwiftTests: XCTestCase {
         switch result {
         case .failure(let error):
             XCTFail(error.description)
-        case .success(let (videos, _)):
-            XCTAssertFalse(videos.isEmpty)
+        case .success(let (data, _, response)):
+            XCTAssertFalse(data.isEmpty)
+            XCTAssertEqual(response.statusCode, 200)
         }
 
     }
@@ -156,8 +163,9 @@ final class PexelsSwiftTests: XCTestCase {
         switch result {
         case .failure(let error):
             XCTFail(error.description)
-        case .success(let (videos, _)):
-            XCTAssertFalse(videos.isEmpty)
+        case .success(let (data, _, response)):
+            XCTAssertFalse(data.isEmpty)
+            XCTAssertEqual(response.statusCode, 200)
         }
     }
 
@@ -169,8 +177,9 @@ final class PexelsSwiftTests: XCTestCase {
         switch result {
         case .failure(let error):
             XCTFail(error.description)
-        case .success(let (videos, _)):
-            XCTAssertFalse(videos.isEmpty)
+        case .success(let (data, _, response)):
+            XCTAssertFalse(data.isEmpty)
+            XCTAssertEqual(response.statusCode, 200)
         }
     }
 
@@ -184,8 +193,9 @@ final class PexelsSwiftTests: XCTestCase {
             switch result {
             case .failure(let error):
                 XCTFail(error.description)
-            case .success(let photo):
-                XCTAssertEqual(photo.id, 2014422)
+            case .success(let (data, response)):
+                XCTAssertEqual(data.id, 2014422)
+                XCTAssertEqual(response.statusCode, 200)
             }
             expectation.fulfill()
         }
@@ -200,8 +210,9 @@ final class PexelsSwiftTests: XCTestCase {
             switch result {
             case .failure(let error):
                 XCTFail(error.description)
-            case .success(let (photos, _)):
-                XCTAssertFalse(photos.isEmpty)
+            case .success(let (data, _, response)):
+                XCTAssertFalse(data.isEmpty)
+                XCTAssertEqual(response.statusCode, 200)
             }
             expectation.fulfill()
         }
@@ -216,8 +227,9 @@ final class PexelsSwiftTests: XCTestCase {
             switch result {
             case .failure(let error):
                 XCTFail(error.description)
-            case .success(let (photos, _)):
-                XCTAssertFalse(photos.isEmpty)
+            case .success(let (data, _, response)):
+                XCTAssertFalse(data.isEmpty)
+                XCTAssertEqual(response.statusCode, 200)
             }
             expectation.fulfill()
         }
@@ -232,8 +244,9 @@ final class PexelsSwiftTests: XCTestCase {
             switch result {
             case .failure(let error):
                 XCTFail(error.description)
-            case .success(let (photos, _)):
-                XCTAssertFalse(photos.isEmpty)
+            case .success(let (data, _, response)):
+                XCTAssertFalse(data.isEmpty)
+                XCTAssertEqual(response.statusCode, 200)
             }
             expectation.fulfill()
         }
@@ -248,8 +261,9 @@ final class PexelsSwiftTests: XCTestCase {
             switch result {
             case .failure(let error):
                 XCTFail(error.description)
-            case .success(let (categories, _)):
-                XCTAssertFalse(categories.isEmpty)
+            case .success(let (data, _, response)):
+                XCTAssertFalse(data.isEmpty)
+                XCTAssertEqual(response.statusCode, 200)
             }
             expectation.fulfill()
         }
@@ -280,8 +294,9 @@ final class PexelsSwiftTests: XCTestCase {
             switch result {
             case .failure(let error):
                 XCTFail(error.description)
-            case .success(let video):
-                XCTAssertEqual(video.id, 6466763)
+            case .success(let (data, response)):
+                XCTAssertEqual(data.id, 6466763)
+                XCTAssertEqual(response.statusCode, 200)
             }
             expectation.fulfill()
         }
@@ -296,8 +311,9 @@ final class PexelsSwiftTests: XCTestCase {
             switch result {
             case .failure(let error):
                 XCTFail(error.description)
-            case .success(let (videos, _)):
-                XCTAssertFalse(videos.isEmpty)
+            case .success(let (data, _, response)):
+                XCTAssertFalse(data.isEmpty)
+                XCTAssertEqual(response.statusCode, 200)
             }
             expectation.fulfill()
         }
@@ -312,8 +328,9 @@ final class PexelsSwiftTests: XCTestCase {
             switch result {
             case .failure(let error):
                 XCTFail(error.description)
-            case .success(let (videos, _)):
-                XCTAssertFalse(videos.isEmpty)
+            case .success(let (data, _, response)):
+                XCTAssertFalse(data.isEmpty)
+                XCTAssertEqual(response.statusCode, 200)
             }
             expectation.fulfill()
         }
@@ -328,8 +345,9 @@ final class PexelsSwiftTests: XCTestCase {
             switch result {
             case .failure(let error):
                 XCTFail(error.description)
-            case .success(let (videos, _)):
-                XCTAssertFalse(videos.isEmpty)
+            case .success(let (data, _, response)):
+                XCTAssertFalse(data.isEmpty)
+                XCTAssertEqual(response.statusCode, 200)
             }
             expectation.fulfill()
         }


### PR DESCRIPTION
## Before

```swift
let result = await pexels.getCuratedPhotos()

switch result {
case .failure(let error):
    print(error.description)
case .success(let (data, paging)):
    // access photos
    // data -> [PSPhoto]
    // paging -> PSPagingInfo
}
```

## After

```swift
let result = await pexels.getCuratedPhotos()

switch result {
case .failure(let error):
    print(error.description)
case .success(let (data, paging, response)):
    // access photos
    // data -> [PSPhoto]
    // paging -> PSPagingInfo
    // response -> HTTPURLResponse
}
```